### PR TITLE
Bazelを導入してみる

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-
+# Ignore all bazel-* symlinks
+/bazel-*

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,19 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@bazel_gazelle//:def.bzl", "gazelle")
 
-# gqzelle:prefix github.com/ryosan-470/slackctl
+# gazelle:prefix github.com/ryosan-470/slackctl
 gazelle(name = "gazelle")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/ryosan-470/slackctl",
+    visibility = ["//visibility:private"],
+    deps = ["//cmd:go_default_library"],
+)
+
+go_binary(
+    name = "slackctl",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,5 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@bazel_gazelle//:def.bzl", "gazelle")
+
+# gqzelle:prefix github.com/ryosan-470/slackctl
+gazelle(name = "gazelle")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,16 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "io_bazel_rules_go",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.5/rules_go-0.16.5.tar.gz"],
+    sha256 = "7be7dc01f1e0afdba6c8eb2b43d2fa01c743be1b9273ab1eaf6c233df078d705",
+)
+http_archive(
+    name = "bazel_gazelle",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.16.0/bazel-gazelle-0.16.0.tar.gz"],
+    sha256 = "7949fc6cc17b5b191103e97481cf8889217263acf52e00b560683413af204fcb",
+)
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+go_rules_dependencies()
+go_register_toolchains()
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+gazelle_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,16 +1,101 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "io_bazel_rules_go",
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.5/rules_go-0.16.5.tar.gz"],
     sha256 = "7be7dc01f1e0afdba6c8eb2b43d2fa01c743be1b9273ab1eaf6c233df078d705",
 )
+
 http_archive(
     name = "bazel_gazelle",
     urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.16.0/bazel-gazelle-0.16.0.tar.gz"],
     sha256 = "7949fc6cc17b5b191103e97481cf8889217263acf52e00b560683413af204fcb",
 )
+
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+
 go_rules_dependencies()
+
 go_register_toolchains()
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+
 gazelle_dependencies()
+
+go_repository(
+    name = "com_github_davecgh_go_spew",
+    importpath = "github.com/davecgh/go-spew",
+    tag = "v1.1.1",
+)
+
+go_repository(
+    name = "com_github_gorilla_websocket",
+    importpath = "github.com/gorilla/websocket",
+    tag = "v1.4.0",
+)
+
+go_repository(
+    name = "com_github_inconshreveable_mousetrap",
+    importpath = "github.com/inconshreveable/mousetrap",
+    tag = "v1.0.0",
+)
+
+go_repository(
+    name = "com_github_lusis_go_slackbot",
+    commit = "401027ccfef5",
+    importpath = "github.com/lusis/go-slackbot",
+)
+
+go_repository(
+    name = "com_github_lusis_slack_test",
+    commit = "3c758769bfa6",
+    importpath = "github.com/lusis/slack-test",
+)
+
+go_repository(
+    name = "com_github_mattn_go_runewidth",
+    importpath = "github.com/mattn/go-runewidth",
+    tag = "v0.0.3",
+)
+
+go_repository(
+    name = "com_github_nlopes_slack",
+    importpath = "github.com/nlopes/slack",
+    tag = "v0.4.0",
+)
+
+go_repository(
+    name = "com_github_olekukonko_tablewriter",
+    importpath = "github.com/olekukonko/tablewriter",
+    tag = "v0.0.1",
+)
+
+go_repository(
+    name = "com_github_pkg_errors",
+    importpath = "github.com/pkg/errors",
+    tag = "v0.8.0",
+)
+
+go_repository(
+    name = "com_github_pmezard_go_difflib",
+    importpath = "github.com/pmezard/go-difflib",
+    tag = "v1.0.0",
+)
+
+go_repository(
+    name = "com_github_spf13_cobra",
+    importpath = "github.com/spf13/cobra",
+    tag = "v0.0.3",
+)
+
+go_repository(
+    name = "com_github_spf13_pflag",
+    importpath = "github.com/spf13/pflag",
+    tag = "v1.0.3",
+)
+
+go_repository(
+    name = "com_github_stretchr_testify",
+    importpath = "github.com/stretchr/testify",
+    tag = "v1.2.2",
+)

--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "root.go",
+        "users.go",
+    ],
+    importpath = "github.com/ryosan-470/slackctl/cmd",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_nlopes_slack//:go_default_library",
+        "@com_github_olekukonko_tablewriter//:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+    ],
+)


### PR DESCRIPTION
Googleが開発しているBazelを導入してみる。一応手元でビルドできるところまで持ってきた。

## 導入の仕方
まずは、 `WORKSPACE` というファイルと、 `BUILD.bazel` というファイルを作成する。 Ref: 62ca9b0
これを作った後、`gazelle` というツールを利用して、必要となる `BUILD.bazel` を自動生成してもらう。 69b2a7c

このプロジェクトでは `vgo` を利用しているので、`vgo` から依存関係として必要となるものを、`WORKSPACE` に追記しなければならないがこれに関しても、自動生成できる。 fffad14

## 動かしてみる
手元の環境に `bazel` が入っていれば次のようなコマンドで簡単に動かすことが可能。

- run 
```console
% bazel run //:slackctl -- users -h
INFO: Analysed target //:slackctl (0 packages loaded).
INFO: Found 1 target...
Target //:slackctl up-to-date:
  bazel-bin/darwin_amd64_stripped/slackctl
INFO: Elapsed time: 0.454s, Critical Path: 0.01s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
Conrtol Slack users

Usage:
  slackctl users [flags]
  slackctl users [command]

Available Commands:
  list        Return all user lists

Flags:
  -h, --help   help for users

Use "slackctl users [command] --help" for more information about a command.
```

- バイナリを生成する

```console
% bazel build //:slackctl
INFO: Analysed target //:slackctl (0 packages loaded).
INFO: Found 1 target...
Target //:slackctl up-to-date:
  bazel-bin/darwin_amd64_stripped/slackctl
INFO: Elapsed time: 0.340s, Critical Path: 0.01s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
```


