### PR TITLE
Add version subcommand

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+test --test_output=errors --test_verbose_timeout_warnings

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,14 @@
 version: 2.1
 executors:
   go:
-    working_directory: /go/src/github.com/ryosan-470/slackctl
     docker:
       - image: circleci/golang:1.11
     environment:
       - GO111MODULE: "on"
+
+  bazel:
+    docker:
+      - image: l.gcr.io/google/bazel:0.21.0
 
 commands:
   prepare_go:
@@ -37,8 +40,20 @@ jobs:
           name: Submit report to Codecov
           command: bash <(curl -s https://codecov.io/bash)
 
+  bazeltest:
+    executor: bazel
+    steps:
+      - checkout
+      - run:
+          name: Run test using bazel
+          command: |
+            bazel test --nokeep_state_after_build --test_output=errors --features=race //...
+
 workflows:
   version: 2
   citest:
     jobs:
       - test
+  cibazeltest:
+    jobs:
+      - bazeltest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,10 +44,19 @@ jobs:
     executor: bazel
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v1-bazel-test-cache-{{ .Branch }}-
+            - v1-bazel-test-cache-master-
+            - v1-bazel-test-cache-
       - run:
           name: Run test using bazel
           command: |
-            bazel test --nokeep_state_after_build --test_output=errors --features=race //...
+            bazel test --disk_cache=/tmp/bazeltest/ --features=race //...
+      - save_cache:
+          key: v1-bazel-test-cache-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - /tmp/bazeltest
 
 workflows:
   version: 2

--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -14,4 +14,14 @@ go_library(
         "@com_github_olekukonko_tablewriter//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "root_test.go",
+        "version_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = ["@com_github_spf13_cobra//:go_default_library"],
 )

--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "root.go",
         "users.go",
+        "version.go",
     ],
     importpath = "github.com/ryosan-470/slackctl/cmd",
     visibility = ["//visibility:public"],

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"io"
 	"os"
 
 	"github.com/nlopes/slack"
@@ -34,12 +35,12 @@ func initConfig() {
 	api = slack.New(token)
 }
 
-func Execute() {
-	cmd := NewCmdRoot()
-	cmd.SetOutput(os.Stdout)
+func Execute(cmd *cobra.Command, stdout, stderr io.Writer) error {
+	cmd.SetOutput(stdout)
 	if err := cmd.Execute(); err != nil {
-		cmd.SetOutput(os.Stderr)
+		cmd.SetOutput(stderr)
 		cmd.Println(err)
-		os.Exit(1)
+		return err
 	}
+	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ func NewCmdRoot() *cobra.Command {
 		Run:   runHelp,
 	}
 	cmd.AddCommand(NewCmdUsers())
+	cmd.AddCommand(NewShowVersion())
 	return cmd
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"bytes"
+
+	"github.com/spf13/cobra"
+)
+
+func executeCommand(c *cobra.Command, args ...string) (stdout, stderr string, err error) {
+	out, outerr := new(bytes.Buffer), new(bytes.Buffer)
+	c.SetArgs(args)
+	if err := Execute(c, out, outerr); err != nil {
+		return "", "", err
+	}
+	return out.String(), outerr.String(), nil
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,16 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var Version = "0.0.1"
+
+func NewShowVersion() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Show version",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Printf("slackctl version: %s\n", Version)
+		},
+	}
+	return cmd
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestNewShowVeesion(t *testing.T) {
+	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
+	rootCmd := NewShowVersion()
+	rootCmd.SetArgs([]string{"version"})
+	err := Execute(rootCmd, stdout, stderr)
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	expected := fmt.Sprintf("slackctl version: %s\n", Version)
+	if stdout.String() != expected {
+		t.Errorf("subcommand version output is invalid:\ngot:\n%s\nexpected:\n%s", stdout.String(), expected)
+	}
+
+	if stderr.Len() != 0 {
+		t.Errorf("expect stderr is nothing but got: %v", stderr)
+	}
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,26 +1,23 @@
 package cmd
 
 import (
-	"bytes"
 	"fmt"
 	"testing"
 )
 
 func TestNewShowVeesion(t *testing.T) {
-	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
-	rootCmd := NewShowVersion()
-	rootCmd.SetArgs([]string{"version"})
-	err := Execute(rootCmd, stdout, stderr)
+	versionCmd := NewShowVersion()
+	stdout, stderr, err := executeCommand(versionCmd, "version")
 	if err != nil {
 		t.Fatalf("Execute error: %v", err)
 	}
 
 	expected := fmt.Sprintf("slackctl version: %s\n", Version)
-	if stdout.String() != expected {
-		t.Errorf("subcommand version output is invalid:\ngot:\n%s\nexpected:\n%s", stdout.String(), expected)
+	if stdout != expected {
+		t.Errorf("subcommand version output is invalid:\ngot:\n%s\nexpected:\n%s", stdout, expected)
 	}
 
-	if stderr.Len() != 0 {
-		t.Errorf("expect stderr is nothing but got: %v", stderr)
+	if len(stderr) != 0 {
+		t.Errorf("expect stderr is nothing but got:\n%s", stderr)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,14 @@
 package main
 
-import "github.com/ryosan-470/slackctl/cmd"
+import (
+	"os"
+
+	"github.com/ryosan-470/slackctl/cmd"
+)
 
 func main() {
-	cmd.Execute()
+	rootCmd := cmd.NewCmdRoot()
+	if err := cmd.Execute(rootCmd, os.Stdout, os.Stderr); err != nil {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
version サブコマンドを追加し、かつ出力をテストできるように書き直しを行った。

```console
% bazel run //:slackctl version
INFO: Invocation ID: 9691692d-d9c9-497d-a025-0e6e49a8f241
INFO: Analysed target //:slackctl (28 packages loaded, 6283 targets configured).
INFO: Found 1 target...
Target //:slackctl up-to-date:
  bazel-bin/darwin_amd64_stripped/slackctl
INFO: Elapsed time: 18.179s, Critical Path: 0.06s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
slackctl version: 0.0.1
```

またついでにCircleCIでのテスト実行ケースに Bazel を利用するようにワークフローを追加してみた。
