### PR TITLE
Add auth command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,11 +58,23 @@ jobs:
           paths:
             - /tmp/bazeltest
 
+  reviewdog:
+    executor: go
+    environment:
+      - REVIEWDOG_VERSION: "0.9.11"
+    steps:
+      - checkout
+      - prepare_go
+      - run: curl -fSL https://github.com/haya14busa/reviewdog/releases/download/$REVIEWDOG_VERSION/reviewdog_linux_amd64 -o reviewdog && chmod +x ./reviewdog
+      - run: go vet ./... 2>&1 | ./reviewdog -f=govet -reporter=github-pr-check
+
 workflows:
   version: 2
   citest:
     jobs:
       - test
-  cibazeltest:
-    jobs:
       - bazeltest
+      - reviewdog:
+          requires:
+            - test
+            - bazeltest

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,8 +60,8 @@ go_repository(
 
 go_repository(
     name = "com_github_nlopes_slack",
+    commit = "5911c620bb31338e391032c7b4032394beda330a",
     importpath = "github.com/nlopes/slack",
-    tag = "v0.4.0",
 )
 
 go_repository(

--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "auth.go",
         "root.go",
         "users.go",
         "version.go",
@@ -12,6 +13,7 @@ go_library(
     deps = [
         "@com_github_nlopes_slack//:go_default_library",
         "@com_github_olekukonko_tablewriter//:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
     ],
 )

--- a/cmd/BUILD.bazel
+++ b/cmd/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
     deps = [
         "@com_github_nlopes_slack//:go_default_library",
         "@com_github_olekukonko_tablewriter//:go_default_library",
-        "@com_github_pkg_errors//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
     ],
 )
@@ -21,9 +20,13 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "auth_test.go",
         "root_test.go",
         "version_test.go",
     ],
     embed = [":go_default_library"],
-    deps = ["@com_github_spf13_cobra//:go_default_library"],
+    deps = [
+        "@com_github_nlopes_slack//:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+    ],
 )

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCmdAuth() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "auth",
+		Short: "auth command",
+		Long:  `This method checks authentication and tells "you" who you are, even if you might be a bot.`,
+	}
+
+	c.AddCommand(SubCmdAuthTest())
+	return c
+}
+
+func SubCmdAuthTest() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "test",
+		Short: "Checks authentication & identity.",
+		Long: `This method checks authentication and tells "you" who you are, even if you might be a bot.
+
+You can also use this method to test whether Slack API authentication is functional.
+
+API Reference is https://api.slack.com/methods/auth.test`,
+		RunE: ShowAuthTest,
+	}
+
+	return c
+}
+
+func ShowAuthTest(c *cobra.Command, args []string) error {
+	_, err := api.AuthTest()
+	if err != nil {
+		return fmt.Errorf("Calling auth.test is failed: %v", err)
+	}
+	c.Println("ok")
+	return nil
+}

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -33,10 +33,11 @@ API Reference is https://api.slack.com/methods/auth.test`,
 }
 
 func ShowAuthTest(c *cobra.Command, args []string) error {
-	_, err := api.AuthTest()
+	response, err := api.AuthTest()
 	if err != nil {
 		return fmt.Errorf("Calling auth.test is failed: %v", err)
 	}
-	c.Println("ok")
+
+	c.Printf("user: %s\nurl: %s\n", response.User, response.URL)
 	return nil
 }

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nlopes/slack"
+)
+
+func TestSubCmdAuthTest(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{
+    "ok": true,
+    "url": "https:\/\/example.slack.com\/",
+    "team": "example",
+    "user": "example",
+    "team_id": "T3A1K77EH",
+    "user_id": "U39SENP7D"
+}`)
+	}))
+	defer ts.Close()
+
+	slack.APIURL = fmt.Sprintf("%s/api/", ts.URL)
+
+	subCmdAuthTest := SubCmdAuthTest()
+	stdout, stderr, err := executeCommand(subCmdAuthTest, "auth", "test")
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	expected := fmt.Sprintf("user: example\nurl: https://example.slack.com/\n")
+
+	if stdout != expected {
+		t.Errorf("got stdout and expected output is not equal\ngot: %s\nexpected: %s\n", stdout, expected)
+	}
+
+	if len(stderr) != 0 {
+		t.Errorf("expect stderr is nothing but got:\n%s", stderr)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,7 +33,7 @@ func runHelp(cmd *cobra.Command, args []string) {
 
 func initConfig() {
 	token := os.Getenv("SLACK_TOKEN")
-	api = slack.New(token)
+	api = slack.New(token, slack.OptionDebug(true))
 }
 
 func Execute(cmd *cobra.Command, stdout, stderr io.Writer) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ func NewCmdRoot() *cobra.Command {
 	}
 	cmd.AddCommand(NewCmdUsers())
 	cmd.AddCommand(NewShowVersion())
+	cmd.AddCommand(NewCmdAuth())
 	return cmd
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,7 +2,11 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 
+	"github.com/nlopes/slack"
 	"github.com/spf13/cobra"
 )
 
@@ -13,4 +17,12 @@ func executeCommand(c *cobra.Command, args ...string) (stdout, stderr string, er
 		return "", "", err
 	}
 	return out.String(), outerr.String(), nil
+}
+
+func dummySlackAPIServer(responseJson string) *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, responseJson)
+	}))
+	slack.APIURL = fmt.Sprintf("%s/api/", ts.URL)
+	return ts
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/lusis/go-slackbot v0.0.0-20180109053408-401027ccfef5 // indirect
 	github.com/lusis/slack-test v0.0.0-20180109053238-3c758769bfa6 // indirect
 	github.com/mattn/go-runewidth v0.0.3 // indirect
-	github.com/nlopes/slack v0.4.0
+	github.com/nlopes/slack v0.4.1-0.20190107041900-5911c620bb31
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/pkg/errors v0.8.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.3 // indirect
 	github.com/nlopes/slack v0.4.0
 	github.com/olekukonko/tablewriter v0.0.1
-	github.com/pkg/errors v0.8.0 // indirect
+	github.com/pkg/errors v0.8.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/mattn/go-runewidth v0.0.3 h1:a+kO+98RDGEfo6asOGMmpodZq4FNtnGP54yps8Bz
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/nlopes/slack v0.4.0 h1:OVnHm7lv5gGT5gkcHsZAyw++oHVFihbjWbL3UceUpiA=
 github.com/nlopes/slack v0.4.0/go.mod h1:jVI4BBK3lSktibKahxBF74txcK2vyvkza1z/+rRnVAM=
+github.com/nlopes/slack v0.4.1-0.20190107041900-5911c620bb31 h1:GLJLerZoA/XLdVS5CdfNXh5H/Bnt6XoqvfHW2IhJPLo=
+github.com/nlopes/slack v0.4.1-0.20190107041900-5911c620bb31/go.mod h1:jVI4BBK3lSktibKahxBF74txcK2vyvkza1z/+rRnVAM=
 github.com/olekukonko/tablewriter v0.0.1 h1:b3iUnf1v+ppJiOfNX4yxxqfWKMQPZR5yoh8urCTFX88=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=


### PR DESCRIPTION
`slackctl auth <revoke/test>` コマンドの作成。

https://api.slack.com/methods/auth.test/ この辺を実装すると、ユーザーが入力したトークン類の情報を取得できる。将来的にはdebugフラグなどをつけたときにこのAPIを呼び出してきて権限的に足りないものがないか? とかを検索できるようにしておきたい。